### PR TITLE
refactor: use `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +193,7 @@ dependencies = [
 name = "rhino-config"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Utility to edit rolling rhino remix config"
 build = "build.rs"
 
 [dependencies]
+anyhow = "1.0.57"
 clap = { version = "~3.1.10", features = ["derive"] }
 indoc = "1.0.4"
 

--- a/src/commands/disable.rs
+++ b/src/commands/disable.rs
@@ -2,13 +2,17 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-pub fn mainline(config_path: &Path) {
-    fs::remove_file(&config_path).expect("Unable to remove mainline config file!");
+use anyhow::{Context, Result};
+
+pub fn mainline(config_path: &Path) -> Result<()> {
+    fs::remove_file(&config_path).context("Unable to remove mainline config file!")?;
     println!("Mainline kernel has been disabled.");
+
+    Ok(())
 }
 
-pub fn snapdpurge(config_path: &Path) {
-    fs::remove_file(&config_path).expect("Unable to remove snapdpurge config file!");
+pub fn snapdpurge(config_path: &Path) -> Result<()> {
+    fs::remove_file(&config_path).context("Unable to remove snapdpurge config file!")?;
     println!("Snapdpurge has been disabled.");
 
     println!("Reinstalling Snapcraft...");
@@ -22,10 +26,12 @@ pub fn snapdpurge(config_path: &Path) {
             "-y",
         ])
         .spawn()
-        .expect("Unable to reinstall snapd!");
+        .context("Unable to reinstall snapd!")?;
 
     Command::new("sudo")
         .args(["apt-mark", "unhold", "snapd"])
         .spawn()
-        .expect("Unable to unhold snapd!");
+        .context("Unable to unhold snapd!")?;
+
+    Ok(())
 }


### PR DESCRIPTION
Refactors to use the [`anyhow` crate](https://crates.io/crates/anyhow) for better error messages, and cleaner code.